### PR TITLE
Hide console.log messages and handle undefined object

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "exif",
   "version": "0.1.0",
-  "main": "exif.js",
+  "main": "jpeg.js",
   "ignore": [
     "test ",
     "node_modules",

--- a/jpeg.js
+++ b/jpeg.js
@@ -1608,17 +1608,17 @@ var tags = {
   "50710": { // Provides a mapping between the values in the CFAPattern tag and the plane numbers in LinearRaw space. This is a required tag for non-RGB CFA images.
     "IFD": 1,
     "key": "CFAPlaneColor",
-    "type": 1,
+    "type": 1
   },
   "50711": { // Describes the spatial layout of the CFA.
     "IFD": 1,
     "key": "CFALayout",
-    "type": 3,
+    "type": 3
   },
   "50712": { // Describes a lookup table that maps stored values into linear values. This tag is typically used to increase compression ratios by storing the raw data in a non-linear, more visually uniform space with fewer total encoding levels. If SamplesPerPixel is not equal to one, this single table applies to all the samples for each pixel.
     "IFD": 1,
     "key": "LinearizationTable",
-    "type": 3,
+    "type": 3
   },
   "50713": { // Specifies repeat pattern size for the BlackLevel tag.
     "IFD": 1,
@@ -1648,7 +1648,7 @@ var tags = {
   "50718": { // DefaultScale is required for cameras with non-square pixels. It specifies the default scale factors for each direction to convert the image to square pixels. Typically these factors are selected to approximately preserve total pixel count. For CFA images that use CFALayout equal to 2, 3, 4, or 5, such as the Fujifilm SuperCCD, these two values should usually differ by a factor of 2.0.
     "IFD": 1,
     "key": "DefaultScale",
-    "type": 5,
+    "type": 5
   },
   "50719": { // Raw images often store extra pixels around the edges of the final image. These extra pixels help prevent interpolation artifacts near the edges of the final image. DefaultCropOrigin specifies the origin of the final image area, in raw image coordinates (i.e., before the DefaultScale has been applied), relative to the top-left corner of the ActiveArea rectangle.
     "IFD": 1,
@@ -1964,7 +1964,7 @@ var tags = {
   "51008": { // Specifies the list of opcodes that should be applied to the raw image, as read directly from the file.
     "IFD": 1,
     "key": "OpcodeList1",
-    "type": 7,
+    "type": 7
   },
   "51009": { // Specifies the list of opcodes that should be applied to the raw image, just after it has been mapped to linear reference values.
     "IFD": 1,
@@ -2224,7 +2224,7 @@ this.JPEG.exifSpec = {
     0xf6 : "JPG6", 0xf7 : "JPG7", 0xf8 : "JPG8",
     0xf9 : "JPG9", 0xfa : "JPG10", 0xfb : "JPG11",
     0xfc : "JPG12", 0xfd : "JPG13",
-    0xfe : "COM",   // COMment
+    0xfe : "COM"   // COMment
   };
 
   var APPSegmentFormats = {
@@ -2235,7 +2235,7 @@ this.JPEG.exifSpec = {
       "segmentType" : "APP1"
     },
     "Exif" : { // Exchangeable image file format
-      "segmentType" : "APP0",
+      "segmentType" : "APP0"
     }
   };
 

--- a/jpeg.js
+++ b/jpeg.js
@@ -1,6 +1,6 @@
 /**
 * jpegjs.js v0.0.1 by @dmarcos 
-* Copyright 2014 Diego Marcos <diego.marcos@gmail.com>
+* Copyright 2015 Diego Marcos <diego.marcos@gmail.com>
 * 
 */
 'use strict';
@@ -2570,7 +2570,7 @@ this.JPEG.exifSpec = {
     Object.keys(entries).forEach(function(tag) {
       tagInfo = entries.IFD === 4? interOperabilityTags.tags[tag] : exifSpec.tags[tag];
       if (!tagInfo) {
-        console.log("Error parsing IFD: Tag  " + tag + " is not valid");
+        if(showErrors) console.log("Error parsing IFD: Tag  " + tag + " is not valid");
         return;
       }
       tags[tagInfo.key] = entries[tag].value;
@@ -2638,6 +2638,8 @@ this.JPEG.exifSpec = {
       JPEGInterchangeFormat = IFD1.entries[exifSpec.getTagId("JPEGInterchangeFormat")].value;
       thumbnailBlob = blobView.blob.slice(TIFFHeaderOffset + JPEGInterchangeFormat, TIFFHeaderOffset + JPEGInterchangeFormat + JPEGInterchangeFormatLength);
     }
+
+    if(typeof IFD0.entries === 'undefined') IFD0.entries = [{}];
 
     // Reads EXIF IFD
     if (IFD0.entries[exifSpec.getTagId("ExifTag")]) {
@@ -2895,7 +2897,7 @@ this.JPEG.exifSpec = {
       // IFDid = 4 (InterOperability)
       offset += writeIFD(blobView, tiffHeaderOffset, offset, offset + interoperabilityIFDLength, 4, metaData);
       if (offset !== segmentLength) {
-        console.log(writtenBytesError);
+        if(showErrors) console.log(writtenBytesError);
         callback(writtenBytesError);
         return;
       }
@@ -2968,6 +2970,11 @@ this.JPEG.exifSpec = {
     "JFIF" : JPEG.JFIF
   };
 
+  var showErrors = false;
+
+  var turnErrorsOn = function() {
+    showErrors = true;
+  };
   var readSegmentMarker = function(blobView, offset) {
     return blobView.getUint8(offset + offsets.segmentMarker);
   };
@@ -3045,7 +3052,7 @@ this.JPEG.exifSpec = {
         "thumbnailBlob" : segment.thumbnailBlob
       };
     } else {
-      console.log("Unkown APP segment format: " + segmentFormat);
+      if(showErrors) console.log("Unkown APP segment format: " + segmentFormat);
     }
   };
 
@@ -3056,7 +3063,7 @@ this.JPEG.exifSpec = {
     var segmentLength;
     while (offset + 4 <= blobView.sliceLength) {
       if (!validateSegment(blobView, offset)) {
-        console.log("Invalid JPEG Segment at offset " + offset);
+        if(showErrors) console.log("Invalid JPEG Segment at offset " + offset);
         break;
       }
       if (isAPPSegment(blobView, offset)) {
@@ -3189,6 +3196,8 @@ this.JPEG.exifSpec = {
   };
 
   this.JPEG = this.JPEG || {};
+  this.showErrors = false;
+  this.JPEG.turnErrorsOn = turnErrorsOn;
   this.JPEG.readMetaData = readMetaData;
   this.JPEG.readExifMetaData = readExifMetaData;
   this.JPEG.writeExifMetaData = writeExifMetaData;

--- a/jpeg.js
+++ b/jpeg.js
@@ -1368,7 +1368,7 @@ var tags = {
   "37521": { // A tag used to record fractions of seconds for the <DateTimeOriginal> tag.
     "IFD": 2,
     "key": "SubSecTimeOriginal",
-    "type": 2,
+    "type": 2
   },
   "37522": { // A tag used to record fractions of seconds for the <DateTimeDigitized> tag.
     "IFD": 2,

--- a/src/exifParser.js
+++ b/src/exifParser.js
@@ -294,7 +294,7 @@
     Object.keys(entries).forEach(function(tag) {
       tagInfo = entries.IFD === 4? interOperabilityTags.tags[tag] : exifSpec.tags[tag];
       if (!tagInfo) {
-        console.log("Error parsing IFD: Tag  " + tag + " is not valid");
+        if(showErrors) console.log("Error parsing IFD: Tag  " + tag + " is not valid");
         return;
       }
       tags[tagInfo.key] = entries[tag].value;
@@ -362,6 +362,8 @@
       JPEGInterchangeFormat = IFD1.entries[exifSpec.getTagId("JPEGInterchangeFormat")].value;
       thumbnailBlob = blobView.blob.slice(TIFFHeaderOffset + JPEGInterchangeFormat, TIFFHeaderOffset + JPEGInterchangeFormat + JPEGInterchangeFormatLength);
     }
+
+    if(typeof IFD0.entries === 'undefined') IFD0.entries = [{}];
 
     // Reads EXIF IFD
     if (IFD0.entries[exifSpec.getTagId("ExifTag")]) {
@@ -619,7 +621,7 @@
       // IFDid = 4 (InterOperability)
       offset += writeIFD(blobView, tiffHeaderOffset, offset, offset + interoperabilityIFDLength, 4, metaData);
       if (offset !== segmentLength) {
-        console.log(writtenBytesError);
+        if(showErrors) console.log(writtenBytesError);
         callback(writtenBytesError);
         return;
       }

--- a/src/exifSpec.js
+++ b/src/exifSpec.js
@@ -896,7 +896,7 @@ var tags = {
   "37521": { // A tag used to record fractions of seconds for the <DateTimeOriginal> tag.
     "IFD": 2,
     "key": "SubSecTimeOriginal",
-    "type": 2,
+    "type": 2
   },
   "37522": { // A tag used to record fractions of seconds for the <DateTimeDigitized> tag.
     "IFD": 2,

--- a/src/exifSpec.js
+++ b/src/exifSpec.js
@@ -1136,17 +1136,17 @@ var tags = {
   "50710": { // Provides a mapping between the values in the CFAPattern tag and the plane numbers in LinearRaw space. This is a required tag for non-RGB CFA images.
     "IFD": 1,
     "key": "CFAPlaneColor",
-    "type": 1,
+    "type": 1
   },
   "50711": { // Describes the spatial layout of the CFA.
     "IFD": 1,
     "key": "CFALayout",
-    "type": 3,
+    "type": 3
   },
   "50712": { // Describes a lookup table that maps stored values into linear values. This tag is typically used to increase compression ratios by storing the raw data in a non-linear, more visually uniform space with fewer total encoding levels. If SamplesPerPixel is not equal to one, this single table applies to all the samples for each pixel.
     "IFD": 1,
     "key": "LinearizationTable",
-    "type": 3,
+    "type": 3
   },
   "50713": { // Specifies repeat pattern size for the BlackLevel tag.
     "IFD": 1,
@@ -1176,7 +1176,7 @@ var tags = {
   "50718": { // DefaultScale is required for cameras with non-square pixels. It specifies the default scale factors for each direction to convert the image to square pixels. Typically these factors are selected to approximately preserve total pixel count. For CFA images that use CFALayout equal to 2, 3, 4, or 5, such as the Fujifilm SuperCCD, these two values should usually differ by a factor of 2.0.
     "IFD": 1,
     "key": "DefaultScale",
-    "type": 5,
+    "type": 5
   },
   "50719": { // Raw images often store extra pixels around the edges of the final image. These extra pixels help prevent interpolation artifacts near the edges of the final image. DefaultCropOrigin specifies the origin of the final image area, in raw image coordinates (i.e., before the DefaultScale has been applied), relative to the top-left corner of the ActiveArea rectangle.
     "IFD": 1,
@@ -1492,7 +1492,7 @@ var tags = {
   "51008": { // Specifies the list of opcodes that should be applied to the raw image, as read directly from the file.
     "IFD": 1,
     "key": "OpcodeList1",
-    "type": 7,
+    "type": 7
   },
   "51009": { // Specifies the list of opcodes that should be applied to the raw image, just after it has been mapped to linear reference values.
     "IFD": 1,

--- a/src/jpegParser.js
+++ b/src/jpegParser.js
@@ -16,6 +16,11 @@
     "JFIF" : JPEG.JFIF
   };
 
+  var showErrors = false;
+
+  var turnErrorsOn = function() {
+    showErrors = true;
+  };
   var readSegmentMarker = function(blobView, offset) {
     return blobView.getUint8(offset + offsets.segmentMarker);
   };
@@ -93,7 +98,7 @@
         "thumbnailBlob" : segment.thumbnailBlob
       };
     } else {
-      console.log("Unkown APP segment format: " + segmentFormat);
+      if(showErrors) console.log("Unkown APP segment format: " + segmentFormat);
     }
   };
 
@@ -104,7 +109,7 @@
     var segmentLength;
     while (offset + 4 <= blobView.sliceLength) {
       if (!validateSegment(blobView, offset)) {
-        console.log("Invalid JPEG Segment at offset " + offset);
+        if(showErrors) console.log("Invalid JPEG Segment at offset " + offset);
         break;
       }
       if (isAPPSegment(blobView, offset)) {
@@ -237,6 +242,8 @@
   };
 
   this.JPEG = this.JPEG || {};
+  this.showErrors = false;
+  this.JPEG.turnErrorsOn = turnErrorsOn;
   this.JPEG.readMetaData = readMetaData;
   this.JPEG.readExifMetaData = readExifMetaData;
   this.JPEG.writeExifMetaData = writeExifMetaData;

--- a/src/jpegSpec.js
+++ b/src/jpegSpec.js
@@ -45,7 +45,7 @@
     0xf6 : "JPG6", 0xf7 : "JPG7", 0xf8 : "JPG8",
     0xf9 : "JPG9", 0xfa : "JPG10", 0xfb : "JPG11",
     0xfc : "JPG12", 0xfd : "JPG13",
-    0xfe : "COM",   // COMment
+    0xfe : "COM"   // COMment
   };
 
   var APPSegmentFormats = {
@@ -56,7 +56,7 @@
       "segmentType" : "APP1"
     },
     "Exif" : { // Exchangeable image file format
-      "segmentType" : "APP0",
+      "segmentType" : "APP0"
     }
   };
 


### PR DESCRIPTION
This is just a quick update that hides console.log messages by default, and adds option to turn them on by calling a turnErrorsOn function. 

Also, it fixes a small error when IFD0.entries is undefined. It simply sets IFD0.entries to an empty array object when it's undefined.