### PR TITLE
Fix metadata reading test.

### DIFF
--- a/test/data/imagesMetaData.js
+++ b/test/data/imagesMetaData.js
@@ -80,10 +80,10 @@ var sampleExifMetaData = {
   },
   "ExposureProgram":2,
   "ISOSpeedRatings":50,
-  "ExifVersion":48,
+  "ExifVersion":[48,50,50,49],
   "DateTimeOriginal":"2013:09:25 13:54:39",
   "DateTimeDigitized":"2013:09:25 13:54:39",
-  "ComponentsConfiguration":1,
+  "ComponentsConfiguration":[1,2,3,0],
   "ShutterSpeedValue":{
     "numerator":3686,
     "denominator":329
@@ -103,10 +103,10 @@ var sampleExifMetaData = {
     "denominator":25
   },
   "SubjectArea":[
-    0,
-    664,
-    37500,
-    7
+    1631,
+    1223,
+    1795,
+    1077
   ],
   "MakerNote":[
     65,
@@ -308,7 +308,7 @@ var sampleExifMetaData = {
   ],
   "SubSecTimeOriginal":"860",
   "SubSecTimeDigitized":"860",
-  "FlashpixVersion":48,
+  "FlashpixVersion": [48,49,48,48],
   "ColorSpace":1,
   "PixelXDimension":2448,
   "PixelYDimension":3264,

--- a/test/js/readTests.js
+++ b/test/js/readTests.js
@@ -18,6 +18,13 @@
     var imageDownloaded = function(error, fileBlob) {
       JPEG.readExifMetaData(fileBlob, function(error, exifMetaData) {
         assert.isNull(error, "the parser shouldn't return an error");
+
+        assert.deepEqual(Object.keys(exifMetaData),
+                         Object.keys(sampleExifMetaData));
+        Object.keys(exifMetaData).forEach((value) => {
+          assert.deepEqual(exifMetaData[value], sampleExifMetaData[value],
+                           "Differing value: " + value);
+        });
         assert.deepEqual(exifMetaData, sampleExifMetaData);
         done();
       });


### PR DESCRIPTION
The sample date was incorrect, and the test will now have a better diagnostic.